### PR TITLE
Feat: 회원가입 기능 구현

### DIFF
--- a/donate/build.gradle.kts
+++ b/donate/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
@@ -1,7 +1,25 @@
 package com.sparta.donate.api.member
 
+import com.sparta.donate.application.member.MemberService
+import com.sparta.donate.dto.member.request.SignUpRequest
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
-class MemberController {
+@RequestMapping("/api/v1/members")
+class MemberController(
+    private val memberService: MemberService
+) {
+
+    @PostMapping("/signup")
+    fun signup(@Valid @RequestBody request: SignUpRequest): ResponseEntity<Unit> {
+        val id = memberService.signup(request)
+        return ResponseEntity.created(URI.create(String.format("/api/v1/members/%d", id))).build()
+    }
+
 }

--- a/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
@@ -1,8 +1,31 @@
 package com.sparta.donate.application.member
 
+import com.sparta.donate.domain.member.Member
+import com.sparta.donate.dto.member.request.SignUpRequest
+import com.sparta.donate.repository.member.MemberRepository
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
-class MemberService {
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: BCryptPasswordEncoder
+) {
+
+    fun signup(request: SignUpRequest): Long {
+
+        if (memberRepository.existsByEmail(request.email)) {
+            TODO("DuplicateEmailException")
+        }
+
+        if (memberRepository.existsByNickname(request.nickname)) {
+            TODO("DuplicateNicknameException")
+        }
+
+        val member = Member.of(request.copy(password = passwordEncoder.encode(request.password)))
+        memberRepository.save(member)
+        return member.id!!
+    }
+
 }
 

--- a/donate/src/main/kotlin/com/sparta/donate/domain/member/Member.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/domain/member/Member.kt
@@ -1,5 +1,6 @@
 package com.sparta.donate.domain.member
 
+import com.sparta.donate.dto.member.request.SignUpRequest
 import com.sparta.donate.global.entity.BaseEntity
 import jakarta.persistence.*
 
@@ -20,7 +21,6 @@ class Member private constructor(
     var id: Long? = null
         private set
 
-
     @Column(name = "nickname", unique = true)
     var nickname: String = _nickname
         private set
@@ -40,6 +40,16 @@ class Member private constructor(
 
     @Column(name = "email", unique = true)
     val email: String = _email
+
+    companion object {
+        fun of(request: SignUpRequest) = Member(
+            _nickname = request.nickname,
+            _name = request.name,
+            _password = request.password,
+            _role = request.role,
+            _email = request.email
+        )
+    }
 
 }
 

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
@@ -1,0 +1,24 @@
+package com.sparta.donate.dto.member.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+
+data class SignUpRequest(
+
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    val email: String,
+
+    @field:Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}${'$'}",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다"
+    )
+    val password: String,
+
+    @field:NotBlank(message = "역할은 필수값입니다.")
+    val role: String,
+
+    val name: String,
+    val nickname: String,
+)

--- a/donate/src/main/kotlin/com/sparta/donate/global/config/PasswordEncodeConfig.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/config/PasswordEncodeConfig.kt
@@ -1,0 +1,11 @@
+package com.sparta.donate.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+@Configuration
+class PasswordEncodeConfig {
+    @Bean
+    fun passwordEncoder() = BCryptPasswordEncoder()
+}

--- a/donate/src/main/kotlin/com/sparta/donate/repository/member/MemberRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/member/MemberRepository.kt
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MemberRepository : JpaRepository<Member, Long>
+interface MemberRepository : JpaRepository<Member, Long> {
+    fun existsByEmail(email: String): Boolean
+    fun existsByNickname(nickname: String): Boolean
+}


### PR DESCRIPTION
Member 엔티티 of 메서드 생성 및 SignUpRequest 생성
validation 관련 의존성 추가
패스워드 인코딩 설정
회원가입 서비스 로직 작성
중복확인 메서드 생성

## 연관 이슈
- closes #5 

## 해당 작업을 한 동기는 무엇인가요?
- 회원가입 기능을 추가하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] 이메일 중복과 닉네임 중복인 회원은 가입을 하지 못하게 설정했습니다.
  - MemberRepository에 관련 메서드를 작성했습니다.

