### PR TITLE
Feat: 로그인 기능 추가

### DIFF
--- a/donate/build.gradle.kts
+++ b/donate/build.gradle.kts
@@ -26,7 +26,12 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
     runtimeOnly("com.h2database:h2")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
 }

--- a/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
@@ -1,7 +1,9 @@
 package com.sparta.donate.api.member
 
 import com.sparta.donate.application.member.MemberService
+import com.sparta.donate.dto.member.request.SignInRequest
 import com.sparta.donate.dto.member.request.SignUpRequest
+import com.sparta.donate.dto.member.response.JwtResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,6 +22,12 @@ class MemberController(
     fun signup(@Valid @RequestBody request: SignUpRequest): ResponseEntity<Unit> {
         val id = memberService.signup(request)
         return ResponseEntity.created(URI.create(String.format("/api/v1/members/%d", id))).build()
+    }
+
+    @PostMapping("/signin")
+    fun signup(@Valid @RequestBody request: SignInRequest): ResponseEntity<JwtResponse> {
+        val jwt = memberService.signin(request)
+        return ResponseEntity.ok(jwt)
     }
 
 }

--- a/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
@@ -1,7 +1,10 @@
 package com.sparta.donate.application.member
 
 import com.sparta.donate.domain.member.Member
+import com.sparta.donate.dto.member.request.SignInRequest
 import com.sparta.donate.dto.member.request.SignUpRequest
+import com.sparta.donate.dto.member.response.JwtResponse
+import com.sparta.donate.global.auth.JwtProvider
 import com.sparta.donate.repository.member.MemberRepository
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
@@ -9,7 +12,8 @@ import org.springframework.stereotype.Service
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val passwordEncoder: BCryptPasswordEncoder
+    private val passwordEncoder: BCryptPasswordEncoder,
+    private val jwtProvider: JwtProvider
 ) {
 
     fun signup(request: SignUpRequest): Long {
@@ -27,5 +31,16 @@ class MemberService(
         return member.id!!
     }
 
-}
+    fun signin(request: SignInRequest): JwtResponse {
+        val (email, password) = request
+        val member = getByEmailAndPassword(email, passwordEncoder.encode(password))
 
+        return jwtProvider.generateJwt(member)
+    }
+
+    private fun getByEmailAndPassword(email: String, password: String): Member {
+        return memberRepository.findByEmailAndPassword(email, passwordEncoder.encode(password))
+            ?: TODO("NoSuchEntityException")
+    }
+
+}

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignInRequest.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignInRequest.kt
@@ -1,0 +1,13 @@
+package com.sparta.donate.dto.member.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class SignInRequest(
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    @field:NotBlank(message = "이메일을 입력해주세요")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호를 입력해주세요")
+    val password: String
+)

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/response/JwtResponse.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/response/JwtResponse.kt
@@ -1,0 +1,6 @@
+package com.sparta.donate.dto.member.response
+
+data class JwtResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtProperties.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtProperties.kt
@@ -1,0 +1,11 @@
+package com.sparta.donate.global.auth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "jwt")
+class JwtProperties(
+    val issuer: String,
+    val accessTokenExpirationHour: Long,
+    val refreshTokenExpirationHour: Long,
+    val secret: String
+)

--- a/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtProvider.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtProvider.kt
@@ -1,0 +1,54 @@
+package com.sparta.donate.global.auth
+
+import com.sparta.donate.domain.member.Member
+import com.sparta.donate.dto.member.response.JwtResponse
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+@Component
+class JwtProvider(
+    private val jwtProperties: JwtProperties
+) {
+
+    private val key = Keys.hmacShaKeyFor(jwtProperties.secret.toByteArray())
+
+    fun generateJwt(member: Member): JwtResponse {
+        val accessToken = generateToken(member)
+        val refreshToken = generateToken()
+
+        return JwtResponse("Bearer $accessToken", refreshToken)
+    }
+
+    private fun generateToken(member: Member): String {
+        val claims = mapOf(
+            "nickname" to member.nickname,
+            "email" to member.email,
+            "role" to member.role
+        )
+
+        return Jwts.builder()
+            .issuer(jwtProperties.issuer)
+            .issuedAt(Date.from(Instant.now()))
+            .claims(claims)
+            .signWith(key)
+            .expiration(Date.from(Instant.now().plus(Duration.ofHours(jwtProperties.accessTokenExpirationHour))))
+            .compact()
+    }
+
+    private fun generateToken(): String {
+        val emptyClaims: Map<String, Any> = emptyMap()
+
+        return Jwts.builder()
+            .issuer(jwtProperties.issuer)
+            .issuedAt(Date.from(Instant.now()))
+            .claims(emptyClaims)
+            .signWith(key)
+            .expiration(Date.from(Instant.now().plus(Duration.ofHours(jwtProperties.refreshTokenExpirationHour))))
+            .compact()
+    }
+
+}

--- a/donate/src/main/kotlin/com/sparta/donate/global/config/JwtPropertyConfig.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/config/JwtPropertyConfig.kt
@@ -1,0 +1,9 @@
+package com.sparta.donate.global.config
+
+import com.sparta.donate.global.auth.JwtProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties::class)
+class JwtPropertyConfig

--- a/donate/src/main/kotlin/com/sparta/donate/repository/member/MemberRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/member/MemberRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
     fun existsByNickname(nickname: String): Boolean
+    fun findByEmailAndPassword(email: String, password: String): Member?
 }


### PR DESCRIPTION
- MemberController, Service 로그인 기능 구현
- .yaml 변수 사용을 위한 JwtProperties 생성 및 Config 적용
- JWT 발급 클래스 JwtProvider 생성 및 JWT 생성 메서드 구현
- 로그인 요청/응답 DTO 생성

## 연관 이슈
- closes #10 

## 해당 작업을 한 동기는 무엇인가요?
- 회원가입을 한 멤버를 위한 로그인 기능을 추가했습니다.
- 로그인 성공시 JWT를 발급하고 이를 리턴합니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] MemberController, Service 로그인 기능 구현
  - 로그인 요청/응답 DTO 생성
- [ ] JWT 발급 구현
  - .yaml 변수 사용을 위한 JwtProperties 생성 및 Config 적용
  - JWT 발급 클래스 JwtProvider 생성 및 JWT 생성 메서드 구현
  - accessToken과 refreshToken을 함께 돌려줌
- [ ] refreshToken을 어떻게 효과적으로 활용할지 고민해보고 추후 수정할 생각입니다.