### PR TITLE
Feat: 프로필 수정 기능 구현

### DIFF
--- a/donate/build.gradle.kts
+++ b/donate/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    implementation("org.springframework.data:spring-data-envers:2.7.2")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")

--- a/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
@@ -1,7 +1,7 @@
 package com.sparta.donate.api.donate
 
 import com.sparta.donate.application.donate.DonateService
-import com.sparta.donate.domain.common.SortOrder
+import com.sparta.donate.global.common.SortOrder
 import com.sparta.donate.dto.donate.request.DonateRequest
 import com.sparta.donate.dto.donate.response.DonateResponse
 import org.springframework.http.HttpStatus

--- a/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
@@ -1,15 +1,14 @@
 package com.sparta.donate.api.member
 
 import com.sparta.donate.application.member.MemberService
+import com.sparta.donate.dto.member.ProfileRequest
+import com.sparta.donate.dto.member.ProfileResponse
 import com.sparta.donate.dto.member.request.SignInRequest
 import com.sparta.donate.dto.member.request.SignUpRequest
 import com.sparta.donate.dto.member.response.JwtResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @RestController
@@ -34,6 +33,15 @@ class MemberController(
     fun logout(): ResponseEntity<Unit> {
         memberService.logout()
         return ResponseEntity.ok().build()
+    }
+
+    @PutMapping("/profile")
+    fun update(@RequestBody request: ProfileRequest): ResponseEntity<ProfileResponse> {
+        // 1. 이메일이 id 가 돼서 비밀번호가 리스트로 들어간다.
+        // 2. 회원가입을 했을 때 사용한 비밀번호도 최근 3번 안에 사용한 비밀번호에 해당한다.
+        // 3. 프로필 수정 Request, Response Dto 생성
+        val profileResponse = memberService.updateProfile(request)
+        return ResponseEntity.ok(profileResponse)
     }
 
 }

--- a/donate/src/main/kotlin/com/sparta/donate/api/post/PostController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/post/PostController.kt
@@ -1,7 +1,7 @@
 package com.sparta.donate.api.post
 
 import com.sparta.donate.application.post.PostService
-import com.sparta.donate.domain.common.SortOrder
+import com.sparta.donate.global.common.SortOrder
 import com.sparta.donate.dto.post.request.CreatePostRequest
 import com.sparta.donate.dto.post.request.UpdatePostRequest
 import com.sparta.donate.dto.post.response.PostResponse

--- a/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
@@ -1,6 +1,6 @@
 package com.sparta.donate.application.donate
 
-import com.sparta.donate.domain.common.SortOrder
+import com.sparta.donate.global.common.SortOrder
 import com.sparta.donate.domain.donate.Donate
 import com.sparta.donate.dto.donate.request.DonateRequest
 import com.sparta.donate.dto.donate.response.DonateResponse

--- a/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
@@ -1,11 +1,15 @@
 package com.sparta.donate.application.member
 
 import com.sparta.donate.domain.member.Member
+import com.sparta.donate.domain.member.PasswordHistory
+import com.sparta.donate.dto.member.ProfileRequest
+import com.sparta.donate.dto.member.ProfileResponse
 import com.sparta.donate.dto.member.request.SignInRequest
 import com.sparta.donate.dto.member.request.SignUpRequest
 import com.sparta.donate.dto.member.response.JwtResponse
 import com.sparta.donate.global.auth.JwtProvider
 import com.sparta.donate.repository.member.MemberRepository
+import com.sparta.donate.repository.password.PasswordRepository
 import jakarta.transaction.Transactional
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
@@ -16,7 +20,8 @@ import org.springframework.stereotype.Service
 class MemberService(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: BCryptPasswordEncoder,
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val passwordRepository: PasswordRepository
 ) {
 
     @Transactional
@@ -32,6 +37,9 @@ class MemberService(
 
         val member = Member.of(request.copy(password = passwordEncoder.encode(request.password)))
         memberRepository.save(member)
+
+        val passwordHistory = PasswordHistory.of(member.email, member.password)
+        passwordRepository.save(passwordHistory)
         return member.id!!
     }
 
@@ -49,6 +57,27 @@ class MemberService(
         val userDetails = SecurityContextHolder.getContext().authentication.principal as UserDetails
         val member = memberRepository.findByNickname(userDetails.username) ?: TODO("throw NoSuchEntityException()")
         member.logout()
+    }
+
+    @Transactional
+    fun updateProfile(request: ProfileRequest): ProfileResponse {
+        val passwordHistories: List<PasswordHistory> = passwordRepository.findAllByEmailOrderByUpdatedAtDesc(request.email)
+        val isDuplicate = passwordHistories.any { passwordEncoder.matches(request.password, it.password) }
+
+        if(isDuplicate) {
+            throw RuntimeException()
+        }
+        val updatedPassword = passwordEncoder.encode(request.password)
+        if (passwordHistories.size <= 3) {
+            passwordRepository.save(PasswordHistory.of(request.email, updatedPassword))
+        } else {
+            passwordHistories[0].update(updatedPassword)
+        }
+
+        val member = memberRepository.findByEmail(request.email) ?: TODO("NoSuchEntityException")
+        member.update(request.introduce, updatedPassword)
+
+        return member.from()
     }
 
     private fun getByEmailAndPassword(email: String, password: String): Member {

--- a/donate/src/main/kotlin/com/sparta/donate/application/post/PostService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/post/PostService.kt
@@ -1,6 +1,6 @@
 package com.sparta.donate.application.post
 
-import com.sparta.donate.domain.common.SortOrder
+import com.sparta.donate.global.common.SortOrder
 import com.sparta.donate.domain.post.Post
 import com.sparta.donate.dto.post.request.CreatePostRequest
 import com.sparta.donate.dto.post.request.UpdatePostRequest

--- a/donate/src/main/kotlin/com/sparta/donate/domain/common/SortOrder.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/domain/common/SortOrder.kt
@@ -1,5 +1,0 @@
-package com.sparta.donate.domain.common
-
-enum class SortOrder {
-    ASC, DESC
-}

--- a/donate/src/main/kotlin/com/sparta/donate/domain/member/Member.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/domain/member/Member.kt
@@ -1,5 +1,6 @@
 package com.sparta.donate.domain.member
 
+import com.sparta.donate.dto.member.ProfileResponse
 import com.sparta.donate.dto.member.request.SignUpRequest
 import com.sparta.donate.global.entity.BaseEntity
 import jakarta.persistence.*
@@ -12,7 +13,8 @@ class Member private constructor(
     _name: String,
     _password: String,
     _role: String,
-    _email: String
+    _email: String,
+    _introduce: String
 ) : BaseEntity() {
 
     @Id
@@ -41,6 +43,9 @@ class Member private constructor(
     var refreshToken: String? = null
         private set
 
+    @Column(name = "introduce")
+    var introduce: String = _introduce
+
     @Column(name = "email", unique = true)
     val email: String = _email
 
@@ -52,13 +57,24 @@ class Member private constructor(
         this.refreshToken = null
     }
 
+    fun update(introduce: String, updatedPassword: String) {
+        this.introduce = introduce
+        this.password = updatedPassword
+    }
+
+    fun from() = ProfileResponse(
+        email = this.email,
+        introduce = this.introduce
+    )
+
     companion object {
         fun of(request: SignUpRequest) = Member(
             _nickname = request.nickname,
             _name = request.name,
             _password = request.password,
             _role = request.role,
-            _email = request.email
+            _email = request.email,
+            _introduce = request.introduce
         )
     }
 

--- a/donate/src/main/kotlin/com/sparta/donate/domain/member/PasswordHistory.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/domain/member/PasswordHistory.kt
@@ -1,0 +1,38 @@
+package com.sparta.donate.domain.member
+
+import com.sparta.donate.global.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "passwords")
+class PasswordHistory private constructor(
+    _email: String,
+    _password: String
+): BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+        private set
+
+    @Column(name = "email")
+    var email: String = _email
+        private set
+
+    @Column(name = "password")
+    var password: String = _password
+        private set
+
+    fun update(password: String) {
+        this.password = password
+    }
+
+    companion object {
+        fun of(email: String, password: String) = PasswordHistory(
+            _email = email,
+            _password = password
+        )
+
+    }
+}
+
+

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/ProfileRequest.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/ProfileRequest.kt
@@ -1,0 +1,17 @@
+package com.sparta.donate.dto.member
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+
+data class ProfileRequest (
+    @field:Email(message = "올바른 이메일 형식이 아닙니다.")
+    @field:NotBlank(message = "이메일을 입력해주세요")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호를 입력해주세요")
+    val password: String,
+
+    @field:NotBlank(message = "자기소개를 입력해주세요")
+    val introduce: String,
+)

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/ProfileResponse.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/ProfileResponse.kt
@@ -1,0 +1,7 @@
+package com.sparta.donate.dto.member
+
+data class ProfileResponse (
+    val email : String,
+    val introduce: String
+)
+

--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
@@ -21,4 +21,7 @@ data class SignUpRequest(
 
     val name: String,
     val nickname: String,
+    val introduce: String,
 )
+
+

--- a/donate/src/main/kotlin/com/sparta/donate/global/common/SortOrder.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/common/SortOrder.kt
@@ -1,0 +1,5 @@
+package com.sparta.donate.global.common
+
+enum class SortOrder {
+    ASC, DESC
+}

--- a/donate/src/main/kotlin/com/sparta/donate/global/entity/BaseEntity.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/entity/BaseEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
@@ -16,4 +17,10 @@ abstract class BaseEntity {
     lateinit var createdAt: LocalDateTime
         protected set
 
+    @Column(columnDefinition = "TIMESTAMP(6)", name = "updated_at", nullable = false)
+    @LastModifiedDate
+    lateinit var updatedAt: LocalDateTime
+        protected set
 }
+
+

--- a/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
@@ -1,0 +1,10 @@
+package com.sparta.donate.repository.password
+
+import com.sparta.donate.domain.member.PasswordHistory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PasswordRepository: JpaRepository<PasswordHistory, Long> {
+    fun findAllByEmailOrderByUpdatedAtDesc(email: String): List<PasswordHistory>
+
+}
+


### PR DESCRIPTION
- Member 엔티티 introduce 추가
- 프로필 수정 컨트롤러 작성
- 프로필 수정 서비스 로직 작성
- PasswordHistory 엔티티 작성
- 프로필 요청, 응답 dto 작성
- SignUpRequest dto 에 introduce 추가

## 연관 이슈
- closes #20 

## 해당 작업을 한 동기는 무엇인가요?
- 프로필 수정 기능을 구현했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] 멤버 엔티티와 회원가입 요청에 자기소개(introduce) 추가
- [ ] 멤버 서비스에 프로필 변경 메서드 updateProfile 구현
