### PR TITLE
Bugfix: Repository 잘못 생성한 메서드, 회원가입 비밀번호 패턴 버그 수정

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/member/request/SignUpRequest.kt
@@ -1,7 +1,8 @@
 package com.sparta.donate.dto.member.request
 
+import com.sparta.donate.domain.member.MemberRole
 import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 
 
@@ -11,13 +12,13 @@ data class SignUpRequest(
     val email: String,
 
     @field:Pattern(
-        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}${'$'}",
-        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다"
+        regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=!])(?=\\S+$).{8,15}$",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상 15자 이하를 충족해야 합니다"
     )
     val password: String,
 
-    @field:NotBlank(message = "역할은 필수값입니다.")
-    val role: String,
+    @field:NotNull(message = "역할은 필수값입니다.")
+    val role: MemberRole,
 
     val name: String,
     val nickname: String,

--- a/donate/src/main/kotlin/com/sparta/donate/repository/donate/DonateRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/donate/DonateRepository.kt
@@ -1,18 +1,12 @@
 package com.sparta.donate.repository.donate
 
 import com.sparta.donate.domain.donate.Donate
-import com.sparta.donate.dto.donate.response.DonateResponse
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface DonateRepository : JpaRepository<Donate, Long> {
-    fun findByMemberIdAndPostId(memberId: Long, postId: Long): Donate?
-
-    fun findAllByOrderByCreatedAtDesc(): List<DonateResponse>
-    fun findAllByOrderByCreatedAtAsc(): List<DonateResponse>
-
-    fun findByPostIdOrderByCreatedAtDesc(postId: Long): List<DonateResponse>
-
-    fun findByPostIdOrderByCreatedAtAsc(postId: Long): List<DonateResponse>
+    fun findByMemberIdAndPostId(memberId: Long, postId: Long):List<Donate>?
+    fun findByPostIdOrderByCreatedAtDesc(postId: Long): List<Donate>
+    fun findByPostIdOrderByCreatedAtAsc(postId: Long): List<Donate>
 }

--- a/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
@@ -4,7 +4,6 @@ import com.sparta.donate.domain.member.PasswordHistory
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PasswordRepository: JpaRepository<PasswordHistory, Long> {
-    fun findAllByEmailOrderByUpdatedAtDesc(email: String): List<PasswordHistory>
-
+    fun findByEmailOrderByUpdatedAtDesc(email: String): List<PasswordHistory>
 }
 

--- a/donate/src/main/kotlin/com/sparta/donate/repository/post/PostRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/post/PostRepository.kt
@@ -1,13 +1,8 @@
 package com.sparta.donate.repository.post
 
 import com.sparta.donate.domain.post.Post
-import com.sparta.donate.dto.post.response.PostResponse
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface PostRepository: JpaRepository<Post, Long> {
-    fun findAllByOrderByCreatedAtDesc(): List<PostResponse>
-    fun findAllByOrderByCreatedAtAsc(): List<PostResponse>
-
-}
+interface PostRepository: JpaRepository<Post, Long>


### PR DESCRIPTION
## 연관 이슈
- closes #24 

## 해당 작업을 한 동기는 무엇인가요?
- 잘못 생성한 메서드와 회원가입 비밀번호 정규식 패턴이 잘못 설정되어 이를 수정하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] DonateRepository, PostRepository, CommentRepository 전체 조회 쿼리 메서드명 변경 또는 삭제
- [x] SignUpRequest 패스워드 @pattern Validation 수정 적용