### PR TITLE
Refactor: 인증 관련 리팩토링

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/global/auth/CustomUserDetailsService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/auth/CustomUserDetailsService.kt
@@ -25,9 +25,9 @@ class CustomUserDetailsService(
 
     private fun generateUserDetails(member: Member): UserDetails =
         User(
-            member.nickname,
+            member.id.toString(),
             "",
-            setOf(SimpleGrantedAuthority("ROLE_${member.role}"))
+            setOf(SimpleGrantedAuthority("ROLE_${member.role.name}"))
         )
 
 }

--- a/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtResolver.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/auth/JwtResolver.kt
@@ -6,8 +6,6 @@ import io.jsonwebtoken.security.Keys
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
-import java.time.Instant
-import java.util.*
 
 @Component
 class JwtResolver(
@@ -16,11 +14,11 @@ class JwtResolver(
 
     private val key = Keys.hmacShaKeyFor(jwtProperties.secret.toByteArray())
 
-    private val BEARER_PATTERN = Regex("^Bearer (.*?)$")
+    private val bearerRegex = Regex("^Bearer (.*?)$")
 
     fun resolveToken(request: HttpServletRequest): String? {
         val header = request.getHeader(HttpHeaders.AUTHORIZATION) ?: return null
-        return BEARER_PATTERN.find(header)?.groupValues?.get(1)
+        return bearerRegex.find(header)?.groupValues?.get(1)
     }
 
     fun verifyAccessToken(accessToken: String): Result<Claims> {
@@ -30,7 +28,6 @@ class JwtResolver(
     fun getClaims(accessToken: String): Claims {
         return Jwts.parser()
             .verifyWith(key)
-            .requireExpiration(Date.from(Instant.now()))
             .build()
             .parseSignedClaims(accessToken)
             .payload


### PR DESCRIPTION
- JwtResolver의 메서드 expiredDate 제거, 변수명 컨벤션 적용
- generateUserDetails 메서드 Enum 문자열 값으로 변경 및 username 을 멤버의 닉네임에서 아이디로 변경

## 연관 이슈
- closes #26 

## 해당 작업을 한 동기는 무엇인가요?
- 기존 버그픽스 또는 리팩터링 변경 전파에 따라 인증과 관련된 메서드를 수정하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] JwtResolver의 메서드 expiredDate 제거, 변수명 컨벤션 적용
- [x] generateUserDetails 메서드 Enum 문자열 값으로 변경 및 username 을 멤버의 닉네임에서 아이디로 변경
