### PR TITLE
refactor: MemberController, 비밀번호 변경 부분 리팩토링

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/member/MemberController.kt
@@ -36,7 +36,7 @@ class MemberController(
     }
 
     @PutMapping("/profile")
-    fun update(@RequestBody request: ProfileRequest): ResponseEntity<ProfileResponse> {
+    fun update(@Valid @RequestBody request: ProfileRequest): ResponseEntity<ProfileResponse> {
         val profileResponse = memberService.updateProfile(request)
         return ResponseEntity.ok(profileResponse)
     }

--- a/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
@@ -68,7 +68,7 @@ class MemberService(
 
     @Transactional
     fun updateProfile(request: ProfileRequest): ProfileResponse {
-        val passwordHistories = passwordRepository.findByEmailOrderByUpdatedAtDesc(request.email)
+        val passwordHistories = passwordRepository.findByEmailOrderByUpdatedAtAsc(request.email)
         val isDuplicate = passwordHistories.any { passwordEncoder.matches(request.password, it.password) }
 
         if (isDuplicate) {

--- a/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/password/PasswordRepository.kt
@@ -4,6 +4,6 @@ import com.sparta.donate.domain.member.PasswordHistory
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PasswordRepository: JpaRepository<PasswordHistory, Long> {
-    fun findByEmailOrderByUpdatedAtDesc(email: String): List<PasswordHistory>
+    fun findByEmailOrderByUpdatedAtAsc(email: String): List<PasswordHistory>
 }
 


### PR DESCRIPTION
- PasswordRepository 내부 메소드 이름 ~Desc 에서 ~Asc 로 변경 (내림차순 -> 오름차순)
- MemberController 내부 update 메소드에 @Valid 어노테이션 추가

## 연관 이슈
- closes #40 

## 해당 작업을 한 동기는 무엇인가요?
- Swagger 테스트 후 발생한 문제를 처리했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] PasswordRepository 내부 메소드 로직을 내림차순 -> 오름차순으로 변경했습니다.
  - ~Desc 에서 ~Asc 로 변경
- [ ] MemberController 내부 update 메소드의 인자인 @RequestBody가 Validation 처리한 DTO를 인식하지 못해서 어노테이션을 추가했습니다.
  - @Valid 어노테이션 추가
