### PR TITLE
Feat: DonateService 예외 처리 기능 추가

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
@@ -39,13 +39,19 @@ class DonateService(
             SortOrder.ASC -> donateRepository.findAll(Sort.by(Sort.Direction.ASC, "createdAt")).map { it.from() }
         }
 
+
     fun getAllDonateListByPostId(postId: Long, sortOrder: SortOrder): List<DonateResponse> {
+
+        // 포스트 아이디가 존재하지 않아 빈 리스트가 반환될 때
+        postRepository.findByIdOrNull(postId) ?: throw NoSuchEntityException("POST")
+
         return when (sortOrder) {
             SortOrder.DESC -> donateRepository.findByPostIdOrderByCreatedAtDesc(postId).map { it.from() }
             SortOrder.ASC -> donateRepository.findByPostIdOrderByCreatedAtAsc(postId).map { it.from() }
         }
     }
 
+    
     @Transactional
     fun deleteDonate(postId: Long, donateId: Long) {
         val donate = donateRepository.findByIdOrNull(donateId) ?: throw NoSuchEntityException("DONATE")
@@ -53,3 +59,5 @@ class DonateService(
     }
 
 }
+
+

--- a/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
@@ -51,7 +51,7 @@ class DonateService(
         }
     }
 
-    
+
     @Transactional
     fun deleteDonate(postId: Long, donateId: Long) {
         val donate = donateRepository.findByIdOrNull(donateId) ?: throw NoSuchEntityException("DONATE")

--- a/donate/src/main/kotlin/com/sparta/donate/repository/comment/CommentRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/comment/CommentRepository.kt
@@ -6,3 +6,4 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface CommentRepository : JpaRepository<Comment, Long>
+


### PR DESCRIPTION
## 연관 이슈
- closes #42 

## 해당 작업을 한 동기는 무엇인가요?
- getAllDonateListByPostId 메서드로 조회 시 해당 게시글이 존재하지 않을 때도 빈 리스트가 반환돼서 예외 처리 기능을 추가했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] getAllDonateListByPostId 메서드에 해당 게시글이 존재하지 않을 때 NoSuchEntityException 으로 예외 처리를 적용했습니다.