### PR TITLE
refactor: 삭제 controller 수정 및 비밀번호 변경 제한 식 수정

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/api/admin/AdminController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/admin/AdminController.kt
@@ -42,12 +42,11 @@ class AdminController(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
-    @DeleteMapping("/donates/{postId}/{donateId}")
+    @DeleteMapping("/donates/{donateId}")
     fun deleteDonateById(
-        @PathVariable postId: Long,
         @PathVariable donateId: Long
     ): ResponseEntity<Unit> {
-        donateService.deleteDonate(postId, donateId)
+        donateService.deleteDonate(donateId)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build()

--- a/donate/src/main/kotlin/com/sparta/donate/api/comment/CommentController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/comment/CommentController.kt
@@ -9,11 +9,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/api/v1/comments/{postId}")
+@RequestMapping("/api/v1/comments")
 class CommentController(
     private val commentService: CommentService
 ) {
-    @PostMapping
+    @PostMapping("/{postId}")
     fun creatComment(
         @PathVariable postId: Long,
         @Valid @RequestBody commentRequest: CommentRequest,
@@ -36,10 +36,9 @@ class CommentController(
 
     @DeleteMapping("/{commentId}")
     fun deleteComment(
-        @PathVariable postId: Long,
         @PathVariable commentId: Long
     ): ResponseEntity<Unit> {
-        commentService.deleteComment(postId, commentId)
+        commentService.deleteComment(commentId)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build()

--- a/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
@@ -15,7 +15,7 @@ class DonateController (
     private val donateService: DonateService
 ) {
 
-    @PostMapping("/{postId}")
+    @PostMapping("/donate/{postId}")
     fun createDonate(
         @PathVariable postId: Long,
         @Valid @RequestBody donateRequest: DonateRequest

--- a/donate/src/main/kotlin/com/sparta/donate/application/comment/CommentService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/comment/CommentService.kt
@@ -49,7 +49,7 @@ class CommentService(
     }
 
     @Transactional
-    fun deleteComment(postId: Long, commentId: Long) {
+    fun deleteComment(commentId: Long) {
         val authenticatedId = getAuthenticationUserId()
         val comment = getByIdOrNull(commentId)
 

--- a/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
@@ -53,7 +53,7 @@ class DonateService(
 
 
     @Transactional
-    fun deleteDonate(postId: Long, donateId: Long) {
+    fun deleteDonate(donateId: Long) {
         val donate = donateRepository.findByIdOrNull(donateId) ?: throw NoSuchEntityException("DONATE")
         donateRepository.delete(donate)
     }

--- a/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/member/MemberService.kt
@@ -82,7 +82,7 @@ class MemberService(
         val updatedPassword = passwordEncoder.encode(request.password)
         member.update(request.introduce, updatedPassword)
 
-        if (passwordHistories.size <= 3) {
+        if (passwordHistories.size < 3) {
             passwordRepository.save(PasswordHistory.of(request.email, updatedPassword))
         } else {
             passwordHistories[0].update(updatedPassword)


### PR DESCRIPTION
- donate와 comment의 삭제 controller 수정
- MemberService 의 updateProfile 메소드에 if문 내부 식 수정

## 연관 이슈
- closes #46 

## 해당 작업을 한 동기는 무엇인가요?
-  donate와 comment 삭제 시 불필요하게 postId를 받아와야 했던 부분을 수정했습니다. 또한 updateProfile 메소드에 if문 내부 식을 수정했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ]  donate와 comment의 controller에서 URI를 수정했고, 이에 맞춰 Service 단에서 메소드를 수정했습니다.
- [ ] 변경된 비밀번호가 4개까지 저장됐던 부분을 수정했습니다.
  - MemberService 의 updateProfile 메소드 내부 if문의 조건식을 수정했습니다.
