### PR TITLE
bugfix: 오류 메세지 변경 안되는 버그 수정

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/global/exception/handler/RestApiExceptionHandler.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/exception/handler/RestApiExceptionHandler.kt
@@ -31,9 +31,9 @@ class RestApiExceptionHandler {
         val errorCode = e.errorCode as CommonErrorCode
         logger.warn("NoSuchEntityException!", e)
 
-        errorCode.message = String.format(errorCode.message, e.entity)
+        val customMessage = String.format(errorCode.message, e.entity)
 
-        return ResponseEntity.status(errorCode.httpStatus()).body(ErrorResponse.of(errorCode))
+        return ResponseEntity.status(errorCode.httpStatus()).body(ErrorResponse.of(errorCode, customMessage))
     }
 
     @ExceptionHandler

--- a/donate/src/main/kotlin/com/sparta/donate/global/exception/response/ErrorResponse.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/exception/response/ErrorResponse.kt
@@ -40,6 +40,9 @@ data class ErrorResponse(
 
         fun of(errorCode: ErrorCode, bindingResult: BindingResult) =
             ErrorResponse(errorCode.errorName(), errorCode.message(), FieldError.of(bindingResult))
+
+        fun of(errorCode: ErrorCode, customMessage: String) =
+            ErrorResponse(errorCode.errorName(), customMessage, null)
     }
 
 }


### PR DESCRIPTION
- ENTITY_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 %s입니다.") 가 호출될 때 %s가 한번 정해지고 나면 더이상 변경이 안되는 버그를 수정했습니다.

## 연관 이슈
- closes #48 

## 해당 작업을 한 동기는 무엇인가요?
- NoSuchEntityException을 throw할 때 한번 정해진 message가 다른 예외처리를 해도 수정되지 않던 버그를 수정했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] ErrorResponse에 에러 메세지를 직접 받아 DTO로 반환하는 of 메소드를 추가했습니다.
  - 기존에 메세지를 바로 CommonErrorCode에 할당하던 로직을 customMessage 변수에 할당해서 ErrorResponse로 반환하게 했습니다.