### PR TITLE
Feat Post, Admin Controller 기능 추가

### DIFF
--- a/donate/src/main/kotlin/com/sparta/donate/api/admin/AdminController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/admin/AdminController.kt
@@ -2,9 +2,11 @@ package com.sparta.donate.api.admin
 
 import com.sparta.donate.application.donate.DonateService
 import com.sparta.donate.application.post.PostService
+import com.sparta.donate.dto.donate.response.DonateResponse
 import com.sparta.donate.dto.post.request.CreatePostRequest
 import com.sparta.donate.dto.post.request.UpdatePostRequest
 import com.sparta.donate.dto.post.response.PostResponse
+import com.sparta.donate.global.common.SortOrder
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -42,15 +44,34 @@ class AdminController(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
-    @DeleteMapping("/donates/{postId}/{donateId}")
-    fun deleteDonateById(
+    @GetMapping("/donates")
+    fun getAllDonateList(
+        @RequestParam sortOrder: SortOrder
+    ): ResponseEntity<List<DonateResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(donateService.getAllDonateList(sortOrder))
+    }
+
+    @GetMapping("/donates/{postId}")
+    fun getAllDonateListByPostId(
         @PathVariable postId: Long,
+        @RequestParam sortOrder: SortOrder
+    ): ResponseEntity<List<DonateResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(donateService.getAllDonateListByPostId(postId, sortOrder))
+    }
+
+    @DeleteMapping("/donates/{donateId}")
+    fun deleteDonateById(
         @PathVariable donateId: Long
     ): ResponseEntity<Unit> {
-        donateService.deleteDonate(postId, donateId)
+        donateService.deleteDonate(donateId)
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build()
     }
 
 }
+

--- a/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/api/donate/DonateController.kt
@@ -3,7 +3,6 @@ package com.sparta.donate.api.donate
 import com.sparta.donate.application.donate.DonateService
 import com.sparta.donate.dto.donate.request.DonateRequest
 import com.sparta.donate.dto.donate.response.DonateResponse
-import com.sparta.donate.global.common.SortOrder
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -26,22 +25,13 @@ class DonateController (
     }
 
     @GetMapping
-    fun getAllDonateList(
-        @RequestParam sortOrder: SortOrder
-    ): ResponseEntity<List<DonateResponse>> {
+    fun getDonateListByMemberId(): ResponseEntity<List<DonateResponse>>{
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(donateService.getAllDonateList(sortOrder))
+            .body(donateService.getDonateListByMemberId())
     }
 
-    @GetMapping("/{postId}")
-    fun getAllDonateListByPostId(
-        @PathVariable postId: Long,
-        @RequestParam sortOrder: SortOrder
-    ): ResponseEntity<List<DonateResponse>> {
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(donateService.getAllDonateListByPostId(postId, sortOrder))
-    }
+
 
 }
+

--- a/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/donate/DonateService.kt
@@ -35,14 +35,14 @@ class DonateService(
 
     fun getAllDonateList(sortOrder: SortOrder): List<DonateResponse> =
         when (sortOrder) {
-            SortOrder.DESC -> donateRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { it.from() }
-            SortOrder.ASC -> donateRepository.findAll(Sort.by(Sort.Direction.ASC, "createdAt")).map { it.from() }
+            SortOrder.DESC -> donateRepository
+                .findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { it.from() }
+            SortOrder.ASC -> donateRepository
+                .findAll(Sort.by(Sort.Direction.ASC, "createdAt")).map { it.from() }
         }
 
 
     fun getAllDonateListByPostId(postId: Long, sortOrder: SortOrder): List<DonateResponse> {
-
-        // 포스트 아이디가 존재하지 않아 빈 리스트가 반환될 때
         postRepository.findByIdOrNull(postId) ?: throw NoSuchEntityException("POST")
 
         return when (sortOrder) {
@@ -51,13 +51,20 @@ class DonateService(
         }
     }
 
+    fun getDonateListByMemberId(): List<DonateResponse>{
+        val authenticatedId = getAuthenticationUserId()
+        return donateRepository.findByMemberId(authenticatedId)?.map { it.from() }
+            ?: throw NoSuchEntityException("DONATE")
+    }
+
 
     @Transactional
-    fun deleteDonate(postId: Long, donateId: Long) {
+    fun deleteDonate(donateId: Long) {
         val donate = donateRepository.findByIdOrNull(donateId) ?: throw NoSuchEntityException("DONATE")
         donateRepository.delete(donate)
     }
 
 }
+
 
 

--- a/donate/src/main/kotlin/com/sparta/donate/application/post/PostService.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/application/post/PostService.kt
@@ -1,6 +1,7 @@
 package com.sparta.donate.application.post
 
 import com.sparta.donate.domain.post.Post
+import com.sparta.donate.dto.comment.response.CommentResponse
 import com.sparta.donate.dto.post.request.CreatePostRequest
 import com.sparta.donate.dto.post.request.UpdatePostRequest
 import com.sparta.donate.dto.post.response.PostResponse
@@ -8,6 +9,7 @@ import com.sparta.donate.global.auth.AuthenticationUtil.getAuthenticationUserId
 import com.sparta.donate.global.common.SortOrder
 import com.sparta.donate.global.exception.common.NoSuchEntityException
 import com.sparta.donate.repository.comment.CommentRepository
+import com.sparta.donate.repository.donate.DonateRepository
 import com.sparta.donate.repository.member.MemberRepository
 import com.sparta.donate.repository.post.PostRepository
 import org.springframework.data.domain.Sort
@@ -19,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional
 class PostService(
     private val postRepository: PostRepository,
     private val memberRepository: MemberRepository,
-    private val commentRepository: CommentRepository
+    private val commentRepository: CommentRepository,
+    private val donateRepository: DonateRepository
 ) {
 
     @Transactional
@@ -33,28 +36,30 @@ class PostService(
 
     fun getAllPostList(sortOrder: SortOrder): List<PostResponse> {
         return when (sortOrder) {
-            SortOrder.DESC -> postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { it.from() }
-            SortOrder.ASC -> postRepository.findAll(Sort.by(Sort.Direction.ASC, "createdAt")).map { it.from() }
+            SortOrder.DESC -> postRepository
+                .findAll(Sort.by(Sort.Direction.DESC, "createdAt")).map { it.from() }
+            SortOrder.ASC -> postRepository
+                .findAll(Sort.by(Sort.Direction.ASC, "createdAt")).map { it.from() }
         }
     }
 
     @Transactional(readOnly = true)
     fun getPostById(postId: Long): PostResponse {
-        val post = postRepository.findByIdOrNull(postId) ?: throw NoSuchEntityException("POST")
-        val commentList = commentRepository.findByPostId(postId).map{ it.from()}
+        val post = getByIdOrNull(postId)
+        val (commentList, donateAmount) = getCommentAndDonateAmountById(postId)
 
-        return post.from(commentList)
+        return post.from(commentList, donateAmount)
     }
 
     @Transactional
     fun updatePost(postId: Long, request: UpdatePostRequest): PostResponse {
         val authenticatedId = getAuthenticationUserId()
         val savedPost = getByIdOrNull(postId)
-        val commentList = commentRepository.findByPostId(postId).map{ it.from()}
+        val (commentList, donateAmount) = getCommentAndDonateAmountById(postId)
 
         savedPost.updatePost(request, authenticatedId)
 
-        return savedPost.from(commentList)
+        return savedPost.from(commentList, donateAmount)
     }
 
     @Transactional
@@ -69,5 +74,13 @@ class PostService(
 
     fun getByIdOrNull(postId: Long) = postRepository.findByIdOrNull(postId) ?: throw NoSuchEntityException("POST")
 
+    fun getCommentAndDonateAmountById(postId: Long): Pair<List<CommentResponse>,Long>{
+        val commentList = commentRepository.findByPostId(postId).map{ it.from()}
+        val donateAmount = donateRepository.findByPostId(postId)?.sumOf{ it.amount} ?: 0
+
+        return Pair(commentList, donateAmount)
+    }
+
 
 }
+

--- a/donate/src/main/kotlin/com/sparta/donate/domain/post/Post.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/domain/post/Post.kt
@@ -1,5 +1,6 @@
 package com.sparta.donate.domain.post
 
+import com.sparta.donate.domain.donate.Donate
 import com.sparta.donate.domain.member.Member
 import com.sparta.donate.dto.comment.response.CommentResponse
 import com.sparta.donate.dto.post.request.CreatePostRequest
@@ -50,19 +51,20 @@ class Post private constructor(
             Post(
                 _title = request.title,
                 _content = request.content,
-                _member = member
+                _member = member,
             )
 
     }
 
-    fun from(commentList: List<CommentResponse> = emptyList()) = PostResponse(
+    fun from(commentList: List<CommentResponse> = emptyList(), donateAmount: Long = 0L) = PostResponse(
             id = id,
             title = title,
             content = content,
             member = member.nickname,
+            amount = donateAmount,
             createdAt = createdAt,
             endedAt = endedAt,
-            commentList = commentList
+            commentList = commentList,
     )
 
 

--- a/donate/src/main/kotlin/com/sparta/donate/dto/post/response/PostResponse.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/dto/post/response/PostResponse.kt
@@ -10,6 +10,7 @@ data class PostResponse(
     val title: String,
     val content: String,
     val member: String,
+    val amount: Long?,
     val commentList: List<CommentResponse>,
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/donate/src/main/kotlin/com/sparta/donate/global/exception/common/NoSuchEntityException.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/global/exception/common/NoSuchEntityException.kt
@@ -4,5 +4,5 @@ import com.sparta.donate.global.exception.ErrorCode
 
 class NoSuchEntityException(
     val entity: String,
-    val errorCode: ErrorCode = CommonErrorCode.ENTITY_NOT_FOUND_ERROR
-) : RuntimeException()
+    val errorCode: ErrorCode = CommonErrorCode.ENTITY_NOT_FOUND_ERROR,
+    ) : RuntimeException()

--- a/donate/src/main/kotlin/com/sparta/donate/repository/donate/DonateRepository.kt
+++ b/donate/src/main/kotlin/com/sparta/donate/repository/donate/DonateRepository.kt
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface DonateRepository : JpaRepository<Donate, Long> {
+    fun findByMemberId(memberId: Long): List<Donate>?
+    fun findByPostId(postId: Long): List<Donate>?
     fun findByMemberIdAndPostId(memberId: Long, postId: Long):List<Donate>?
     fun findByPostIdOrderByCreatedAtDesc(postId: Long): List<Donate>
     fun findByPostIdOrderByCreatedAtAsc(postId: Long): List<Donate>


### PR DESCRIPTION
## 연관 이슈
- closes #50 

## 해당 작업을 한 동기는 무엇인가요?
- Post response에 후원 총액 반환값을 추가하고 Admin controller의 권한 기능을 수정했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] AdminController 에서 getAllDonateList, getAllDonateListByPostId 메서드로 후원 내역 조회 기능을 어드민의 권한으로 수정
- [ ] DonateController 에서 getDonateListByMemberId 메서드로 현재 로그인 한 멤버의 후원 내역 리스트로 반환
- [ ] DonateRepository 에 findByMemberId, findByPostId 메서드 생성
- [ ] Post from 메서드 후원 총액 반환값 추가

